### PR TITLE
Try to fix dependabot missing user for "dependabot[bot]'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,14 +15,17 @@ async function run() {
 
         console.log(`Will check if ${username} belongs to ${team}`)
         
-        // TODO : probably needs to have proper error handling here
-        let data = api.rest.teams.getMembershipForUserInOrg({
-              org: organization,
-              team_slug: team,
-              username: username,
-            });
+        try {
+            let data = api.rest.teams.getMembershipForUserInOrg({
+                  org: organization,
+                  team_slug: team,
+                  username: username,
+                });
         
-        let isTeamMember = data.role && data.state === 'active';
+            let isTeamMember = data.role && data.state === 'active';
+        } catch (membershipError) {
+            let isTeamMember = false
+        }
 
         core.setOutput("isTeamMember", isTeamMember)
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ async function run() {
 
         console.log(`Will check if ${username} belongs to ${team}`)
         
+        // TODO : probably needs to have proper error handling here
         let data = api.rest.teams.getMembershipForUserInOrg({
               org: organization,
               team_slug: team,


### PR DESCRIPTION
When running this script on dependabot PRs, we get the following error, which might be related to dealing with non-existing users:

```
  name: 'GraphqlError',
  request: {
    query: 'query($cursor: String, $org: String!, $userLogins: [String!], $username: String!)  {\n' +
      '            user(login: $username) {\n' +
      '                id\n' +
      '            }\n' +
      '            organization(login: $org) {\n' +
      '              teams (first:1, userLogins: $userLogins, after: $cursor) { \n' +
      '                  nodes {\n' +
      '                    name\n' +
      '                }\n' +
      '                pageInfo {\n' +
      '                  hasNextPage\n' +
      '                  endCursor\n' +
      '                }        \n' +
      '              }\n' +
      '            }\n' +
      '        }',
    variables: {
      cursor: null,
      org: 'elastic',
      userLogins: [Array],
      username: 'dependabot[bot]'
    }
  }
}
Error: Could not resolve to a User with the login of 'dependabot[bot]'.
```